### PR TITLE
Ensure that arrays are parsed correctly in Piwik.

### DIFF
--- a/src/Knp/PiwikClient/Connection/PiwikConnection.php
+++ b/src/Knp/PiwikClient/Connection/PiwikConnection.php
@@ -50,6 +50,11 @@ class PiwikConnection implements ConnectionInterface
 
         foreach ($params as $key => $val) {
             if (is_array($val)) {
+                array_walk($val, function ($value, $key) use (&$val) {
+                    if (!is_array($value)) {
+                        $val[$key] = urlencode($value);
+                    }
+                });
                 $val = implode(',', $val);
             } elseif ($val instanceof \DateTime) {
                 $val = $val->format('Y-m-d');

--- a/tests/Knp/PiwikClient/Connection/HttpConnectionTest.php
+++ b/tests/Knp/PiwikClient/Connection/HttpConnectionTest.php
@@ -66,10 +66,10 @@ class HttpConnectionTest extends \PHPUnit_Framework_TestCase
                     'bool1'  => true,
                     'bool2'  => false,
                     'date'   => new \DateTime('2009/03/12', new \DateTimeZone('Europe/Paris')),
-                    'arr'    => array(2, 3, 4),
+                    'arr'    => array(2, 3, 4, 'mam,bo'),
                     'format' => 'php'
                 ),
-                $this->domain.'?method=Actions.getOutlinks&idSite=2&period=week&bool1=1&date=2009-03-12&arr=2,3,4&format=php&module=API'
+                $this->domain.'?method=Actions.getOutlinks&idSite=2&period=week&bool1=1&date=2009-03-12&arr=2,3,4,mam%2Cbo&format=php&module=API'
             )
         );
     }


### PR DESCRIPTION
Array arguments are sent as strings, so we must be sure that we correctly urlencode them.
